### PR TITLE
Adds several formatting functions and respective configuration options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ log.levels('foo', log.WARN)   // set level of stream named 'foo' to WARN
 * `writers`: Map of log level string names to console functions, default is
   `null`. Use this to customize the functions used when `console` is `true`,
   see [writers](#writers).
+* `pedantic`: A boolean or string which indicates messages should be reformatted to end with a period.  If a string, the string is used instead of a period.
+* `capitalize`: A boolean which indicates all messages should be reformatted to begin with an uppercase letter.
+* `normalize`: A shortcut for `pedantic: true` and `capitalize: true`.
+* `formatter`: A custom function which accepts a string and returns a string.  Applied to all messages after parameter interpolation.
 
 If you specify any unknown properties in the configuration then these are considered *persistent fields* and are added to every log record. This is a convenient way to add labels for sub-components to log records.
 

--- a/test/unit/formatters.js
+++ b/test/unit/formatters.js
@@ -1,0 +1,136 @@
+var expect = require('chai').expect;
+var logger = require('../..');
+
+describe('cli-logger:', function () {
+  it('should write using normalize flag if present', function (done) {
+    var msg = 'mock write %s';
+    var parameters = ['info'];
+    var expected = 'Mock write info.';
+    var name = 'mock-write-logger';
+    var conf = {name: name, json: true, streams: [
+      {path: 'log/mock-write.log'}
+    ], normalize: true};
+    var log = logger(conf);
+    log.on('write', function (record) {
+      expect(record.msg).to.eql(expected);
+      expect(record.err.message).to.eql('boom');
+      done();
+    });
+    log.info(new Error('boom'), msg, parameters[0]);
+  });
+  it('should prefer normalize flag over custom pedantic string', function (done) {
+    var msg = 'mock write %s';
+    var parameters = ['info'];
+    var expected = 'Mock write info.';
+    var name = 'mock-write-logger';
+    var conf = {name: name, json: true, streams: [
+      {path: 'log/mock-write.log'}
+    ], normalize: true, pedantic: '?'};
+    var log = logger(conf);
+    log.on('write', function (record) {
+      expect(record.msg).to.eql(expected);
+      expect(record.err.message).to.eql('boom');
+      done();
+    });
+    log.info(new Error('boom'), msg, parameters[0]);
+  });
+  it('should not attempt format a stringified object', function (done) {
+    var msg = {foo: 'bar'};
+    var expected = JSON.stringify(msg);
+    var name = 'mock-write-logger';
+    var conf = {name: name, json: false, streams: [
+      {path: 'log/mock-write.log'}
+    ], normalize: true, pedantic: true, capitalize: true, formatter: function formatter(msg) {
+      return msg.replace(/"/g, "'");
+    }};
+    var log = logger(conf);
+    log.on('write', function (record) {
+      expect(record.msg).to.eql(expected);
+      done();
+    });
+    log.info(msg);
+  });
+  it('should not attempt format a stringified array', function (done) {
+    var msg = ['bar'];
+    var expected = JSON.stringify(msg);
+    var name = 'mock-write-logger';
+    var conf = {name: name, json: false, streams: [
+      {path: 'log/mock-write.log'}
+    ], normalize: true, pedantic: true, capitalize: true, formatter: function formatter(msg) {
+      return msg.replace(/"/g, "'");
+    }};
+    var log = logger(conf);
+    log.on('write', function (record) {
+      expect(record.msg).to.eql(expected);
+      done();
+    });
+    log.info(msg);
+  });
+  it('should capitalize the first letter of the message', function (done) {
+    var msg = 'mock write %s';
+    var parameters = ['info'];
+    var expected = 'Mock write info';
+    var name = 'mock-write-logger';
+    var conf = {name: name, json: true, streams: [
+      {path: 'log/mock-write.log'}
+    ], capitalize: true};
+    var log = logger(conf);
+    log.on('write', function (record) {
+      expect(record.msg).to.eql(expected);
+      expect(record.err.message).to.eql('boom');
+      done();
+    });
+    log.info(new Error('boom'), msg, parameters[0]);
+  });
+  it('should end the string with a period', function (done) {
+    var msg = 'mock write %s';
+    var parameters = ['info'];
+    var expected = 'mock write info.';
+    var name = 'mock-write-logger';
+    var conf = {name: name, json: true, streams: [
+      {path: 'log/mock-write.log'}
+    ], pedantic: true};
+    var log = logger(conf);
+    log.on('write', function (record) {
+      expect(record.msg).to.eql(expected);
+      expect(record.err.message).to.eql('boom');
+      done();
+    });
+    log.info(new Error('boom'), msg, parameters[0]);
+
+  });
+  it('should leverage custom pedantic "period" if present', function (done) {
+    var msg = 'mock write info';
+    var expected = 'mock write info!@!~!~!~!11!1!';
+    var name = 'mock-write-logger';
+    var conf = {name: name, json: true, streams: [
+      {path: 'log/mock-write.log'}
+    ], pedantic: '!@!~!~!~!11!1!'};
+    var log = logger(conf);
+    log.on('write', function (record) {
+      expect(record.msg).to.eql(expected);
+      expect(record.err.message).to.eql('boom');
+      done();
+    });
+    log.info(new Error('boom'), msg);
+  });
+  it('should allow a user-defined formatter', function (done) {
+    var msg = 'mock write %s';
+    var formatter = function formatter(msg) {
+      return msg.replace('write', 'WRITE');
+    };
+    var parameters = ['info'];
+    var expected = 'mock WRITE info';
+    var name = 'mock-write-logger';
+    var conf = {name: name, json: true, streams: [
+      {path: 'log/mock-write.log'}
+    ], formatter: formatter};
+    var log = logger(conf);
+    log.on('write', function (record) {
+      expect(record.msg).to.eql(expected);
+      expect(record.err.message).to.eql('boom');
+      done();
+    });
+    log.info(new Error('boom'), msg, parameters[0]);
+  });
+});


### PR DESCRIPTION
Adds several formatting functions and respective configuration options.
- `pedantic`: End your messages with a `.` or user-specified string
- `capitalize`: Begin your message with a capital letter
- `normalize`: A shortcut for `pedantic: true` and `capitalize: true`
- `formatter`: User-defined function to reformat any message

I _think_ these are OK, because while the module must be 100% bunyan-compatible, it _can_ be a superset, correct?

My only other concern is `index.js:427` which is a pretty flimsy attempt to detect an object or array converted into JSON.  The alternative is to attempt to `JSON.parse()` it, but that's a fair bit of overhead for a "nice-to-have" feature.

Anyway, if you don't like and/or cannot use these changes, is it possible to at least retain `Logger.prototype._formatMessage` as an "abstract" (empty) function + its invocation, so that I can subclass `Logger`?

tests + docs
